### PR TITLE
Fixed bug on 32 bit systems

### DIFF
--- a/FieldtypeColor.module
+++ b/FieldtypeColor.module
@@ -66,6 +66,9 @@ class FieldtypeColor extends Fieldtype {
 
 	public function wakeupValue(Page $page, Field $field, $value) {
 		if (!$value) return $value;
+		//Get the correct number out of the unsigned integer given as string in $value. This has to be done because dechex()
+		//converts its parameter to int which on 32 bit systems cannot store the value of an unsigned 32 bit int.
+		$value = (float)$value;
 		$value = str_pad(dechex($value), 8, '0', STR_PAD_LEFT);
 		return $value;
 	}


### PR DESCRIPTION
as described in the inline comment. I stumbled upon this as I moved an existing Processwire project from a 64 bit to a 32 bit machine and suddenly all my colors were #ffffff
see also http://php.net/manual/de/function.dechex.php#71795