### PR TITLE
Fixes a bug when the opacity == 0.00

### DIFF
--- a/FieldtypeColor.module
+++ b/FieldtypeColor.module
@@ -165,7 +165,7 @@ class FieldtypeColor extends Fieldtype {
 		// opacity
 		if (in_array($of ,array(3,5,8))) {
 			$opacity = round($value[0] / 255, 2); // float
-			$opacity = rtrim(number_format($opacity, 2, '.', ''),'.0'); // convert float to string with dot as decimal separator
+			$opacity = number_format($opacity, 2, '.', ''); // convert float to string with dot as decimal separator
 		}
  
 		if ($of === 8) {


### PR DESCRIPTION
When the opacity is set to 0, the rgba output became `rgba(255, 255, 255,)`. This caused problems in some browsers because the last alpha value is missing.
Having a value of `0.00` instead of nothing is ok for both `rgba` and `hsla`.