### PR TITLE
Update spectrum change event .

### DIFF
--- a/InputfieldColor.module
+++ b/InputfieldColor.module
@@ -219,7 +219,11 @@ class InputfieldColor extends Inputfield {
 				    $options
 				    color: \"$value\",
 				    change: function(color) {
-				    	this.value = color.toHex8String(); 
+				    	if(color === null){
+					    this.value = 0;
+					}else{
+					    this.value = color.toHex8String(); 
+					}
 				    }
 				});
 			</script>


### PR DESCRIPTION
Set field value to 0 if the color parameter is null as a result of showEmpty option enabled on spectrum.