### PR TITLE
Fix PHP 8.1 deprecation warning on strlen()

### DIFF
--- a/FieldtypeColor.module
+++ b/FieldtypeColor.module
@@ -320,7 +320,7 @@ class FieldtypeColor extends Fieldtype {
 
 		$f->description = $this->_('This value is assigned as the default for blank fields and on newly created pages.');
 		$f->collapsed = Inputfield::collapsedBlank;
-		$f->attr('value', strlen($field->defaultValue) ? $this->sanitizeValue($this->wire('page'), $field, $field->defaultValue) : null);
+		$f->attr('value', strlen($field->defaultValue ?? '') ? $this->sanitizeValue($this->wire('page'), $field, $field->defaultValue) : null);
 
 		$inputfields->add($f); 
 		

--- a/InputfieldColor.module
+++ b/InputfieldColor.module
@@ -162,7 +162,7 @@ class InputfieldColor extends Inputfield {
 	}
 
 	public function ___render() {
-		if ($this->value === "" && strlen($this->initValue)) $this->value = $this->initValue;
+		if ($this->value === "" && strlen($this->initValue ?? '')) $this->value = $this->initValue;
 		if (!$this->value) $this->value = null;
 
 		if ($this->value) {


### PR DESCRIPTION
Avoid warning if defaultValue or initValue is empty.